### PR TITLE
fix: harden FML import URI and SQL upload against RCE chain

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -34,5 +34,7 @@ jobs:
       run: ./mvnw -B package
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    # Fork pull requests only get a read-only token, so the snapshot submission cannot succeed there; skip it for them
     - name: Update dependency graph
+      if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ IntelliJ IDEA IntelliJ IDEA Plugins
 - Code style template: docs/Alibaba_CodeStyle.xml
 - ErrorProne: https://errorprone.info/docs/installation
 
+## Security Notice
+
+The `fastmodel-ide-open` web service (default port 7001) does not provide built-in authentication. Do not expose it directly to untrusted networks; deploy it behind an authenticating gateway or reverse proxy, or restrict access to trusted networks only.
+
 ## Documentation
 
 FML文档可The introduction and guide of the FML can be found under the `doc/` directory, the docs is managed with the Docsify, to learn more about it: docsify quickstart

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -88,6 +88,10 @@ IntelliJ IDEA IntelliJ IDEA插件
 
 
 
+## 安全提示
+
+`fastmodel-ide-open` Web 服务（默认端口 7001）不提供内置认证，请勿直接暴露在不可信网络中；部署时应置于带认证的网关或反向代理之后，或仅允许可信网络访问。
+
 ## 文档
 
 FML文档的介绍和指南可以在doc/目录下找到，文档是通过Docsify管理的，要了解更多信息请参阅：docsify快速入门

--- a/fastmodel-ide/fastmodel-ide-open/src/main/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImpl.java
+++ b/fastmodel-ide/fastmodel-ide-open/src/main/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImpl.java
@@ -41,16 +41,18 @@ import org.springframework.web.multipart.MultipartFile;
  */
 @Component
 public class FileStorageServiceImpl implements StorageService {
-    private final Path root = Paths.get(System.getProperty("java.io.tmpdir"));
+
+    /**
+     * Uploads are stored in a dedicated directory under the temp folder instead of the temp
+     * folder itself, so a sanitized file name can never overwrite unrelated temp files.
+     */
+    private final Path root = Paths.get(System.getProperty("java.io.tmpdir"), "fastmodel-ide-uploads");
 
     @Override
     @PostConstruct
     public void init() {
         try {
-            if (root.toFile().exists()) {
-                return;
-            }
-            Files.createDirectory(root);
+            Files.createDirectories(root);
         } catch (IOException e) {
             throw new RuntimeException("Could not initialize folder for upload!", e);
         }
@@ -58,20 +60,21 @@ public class FileStorageServiceImpl implements StorageService {
 
     @Override
     public Resource save(MultipartFile file) {
+        String safeName = sanitizeFilename(file.getOriginalFilename());
         try {
-            Path resolve = root.resolve(file.getOriginalFilename());
+            Path resolve = resolveInRoot(safeName);
             Files.copy(file.getInputStream(), resolve, StandardCopyOption.REPLACE_EXISTING);
             Resource resource = new UrlResource(resolve.toUri());
             return resource;
         } catch (Exception e) {
-            throw new RuntimeException("Could not store the file. Error: " + file.getOriginalFilename(), e);
+            throw new RuntimeException("Could not store the file. Error: " + safeName, e);
         }
     }
 
     @Override
     public Resource load(String filename) {
         try {
-            Path file = root.resolve(filename);
+            Path file = resolveInRoot(sanitizeFilename(filename));
             Resource resource = new UrlResource(file.toUri());
 
             if (resource.exists() || resource.isReadable()) {
@@ -82,6 +85,33 @@ public class FileStorageServiceImpl implements StorageService {
         } catch (MalformedURLException e) {
             throw new RuntimeException("Error: " + e.getMessage());
         }
+    }
+
+    /**
+     * Rejects any client-supplied file name that contains path separators or traversal
+     * components; uploads must use a plain file name.
+     */
+    private String sanitizeFilename(String filename) {
+        if (filename == null || filename.trim().isEmpty()) {
+            throw new IllegalArgumentException("File name must not be empty");
+        }
+        String name = filename.trim();
+        if (name.contains("/") || name.contains("\\") || name.contains("..")) {
+            throw new IllegalArgumentException("Illegal file name: " + filename);
+        }
+        return name;
+    }
+
+    /**
+     * Resolves the sanitized name against the storage root and guarantees the final path stays
+     * inside the root directory (defense in depth against path traversal).
+     */
+    private Path resolveInRoot(String safeName) {
+        Path resolve = root.resolve(safeName).normalize();
+        if (!resolve.startsWith(root.normalize())) {
+            throw new IllegalArgumentException("Path traversal detected: " + safeName);
+        }
+        return resolve;
     }
 
     @Override

--- a/fastmodel-ide/fastmodel-ide-open/src/main/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImpl.java
+++ b/fastmodel-ide/fastmodel-ide-open/src/main/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImpl.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
@@ -46,13 +47,31 @@ public class FileStorageServiceImpl implements StorageService {
      * Uploads are stored in a dedicated directory under the temp folder instead of the temp
      * folder itself, so a sanitized file name can never overwrite unrelated temp files.
      */
-    private final Path root = Paths.get(System.getProperty("java.io.tmpdir"), "fastmodel-ide-uploads");
+    private final Path root;
+
+    public FileStorageServiceImpl() {
+        this(Paths.get(System.getProperty("java.io.tmpdir"), "fastmodel-ide-uploads"));
+    }
+
+    FileStorageServiceImpl(Path root) {
+        this.root = root;
+    }
 
     @Override
     @PostConstruct
     public void init() {
         try {
+            // a pre-planted symlink at the well-known path would redirect every upload outside
+            // the storage root, so refuse to use it
+            if (Files.isSymbolicLink(root)) {
+                throw new IllegalStateException("Upload folder must not be a symbolic link: " + root);
+            }
             Files.createDirectories(root);
+            try {
+                Files.setPosixFilePermissions(root, PosixFilePermissions.fromString("rwx------"));
+            } catch (UnsupportedOperationException ignored) {
+                // non-POSIX file system
+            }
         } catch (IOException e) {
             throw new RuntimeException("Could not initialize folder for upload!", e);
         }
@@ -88,18 +107,31 @@ public class FileStorageServiceImpl implements StorageService {
     }
 
     /**
-     * Rejects any client-supplied file name that contains path separators or traversal
-     * components; uploads must use a plain file name.
+     * Rejects any client-supplied file name that is not a plain file name: the exact path
+     * components "." and "..", any path separator, and control characters. Consecutive dots
+     * inside a plain name (e.g. "report..final.sql") are harmless once separators are banned
+     * and are allowed.
      */
     private String sanitizeFilename(String filename) {
         if (filename == null || filename.trim().isEmpty()) {
             throw new IllegalArgumentException("File name must not be empty");
         }
         String name = filename.trim();
-        if (name.contains("/") || name.contains("\\") || name.contains("..")) {
+        if (name.equals(".") || name.equals("..") || name.contains("/") || name.contains("\\")
+            || containsControlCharacter(name)) {
             throw new IllegalArgumentException("Illegal file name: " + filename);
         }
         return name;
+    }
+
+    private boolean containsControlCharacter(String name) {
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            if (c < 0x20 || c == 0x7f) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**
@@ -117,6 +149,12 @@ public class FileStorageServiceImpl implements StorageService {
     @Override
     public void deleteAll() {
         FileSystemUtils.deleteRecursively(root.toFile());
+        try {
+            // deleteRecursively removes the root itself; recreate it so save/loadAll keep working
+            Files.createDirectories(root);
+        } catch (IOException e) {
+            throw new RuntimeException("Could not re-create folder for upload!", e);
+        }
     }
 
     @Override

--- a/fastmodel-ide/fastmodel-ide-open/src/test/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImplTest.java
+++ b/fastmodel-ide/fastmodel-ide-open/src/test/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImplTest.java
@@ -19,7 +19,9 @@ package com.aliyun.fastmodel.ide.open.service.impl;
 import java.nio.charset.StandardCharsets;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.springframework.core.io.Resource;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.util.StreamUtils;
@@ -34,11 +36,14 @@ import static org.junit.Assert.fail;
  */
 public class FileStorageServiceImplTest {
 
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
     private FileStorageServiceImpl storage;
 
     @Before
-    public void setUp() {
-        storage = new FileStorageServiceImpl();
+    public void setUp() throws Exception {
+        storage = new FileStorageServiceImpl(temporaryFolder.newFolder("uploads").toPath());
         storage.init();
     }
 
@@ -90,8 +95,23 @@ public class FileStorageServiceImplTest {
     }
 
     @Test
-    public void saveRejectsDotSegments() {
+    public void saveRejectsDotComponents() {
         assertRejected("..");
+        assertRejected(".");
+    }
+
+    @Test
+    public void saveRejectsControlCharacters() {
+        assertRejected("evil\u0000.sql");
+        assertRejected("evil\n.sql");
+    }
+
+    @Test
+    public void saveAllowsConsecutiveDotsInsidePlainName() throws Exception {
+        // separators are banned, so dots inside a plain name cannot traverse
+        Resource resource = storage.save(file("report..final.sql"));
+        assertTrue(resource.exists());
+        assertEquals("report..final.sql", resource.getFilename());
     }
 
     @Test
@@ -111,5 +131,14 @@ public class FileStorageServiceImplTest {
         assertTrue(loaded.exists());
         String content = StreamUtils.copyToString(loaded.getInputStream(), StandardCharsets.UTF_8);
         assertEquals("CREATE TABLE t (id INT);", content);
+    }
+
+    @Test
+    public void deleteAllKeepsStorageUsable() throws Exception {
+        storage.save(file("to_delete.sql"));
+        storage.deleteAll();
+        // save must keep working after deleteAll removed the root directory
+        Resource resource = storage.save(file("after_delete.sql"));
+        assertTrue(resource.exists());
     }
 }

--- a/fastmodel-ide/fastmodel-ide-open/src/test/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImplTest.java
+++ b/fastmodel-ide/fastmodel-ide-open/src/test/java/com/aliyun/fastmodel/ide/open/service/impl/FileStorageServiceImplTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2021-2022 Alibaba Group Holding Ltd.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.aliyun.fastmodel.ide.open.service.impl;
+
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.core.io.Resource;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.util.StreamUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Security tests for {@link FileStorageServiceImpl}. Uploaded file names must never escape the
+ * storage root directory (path traversal protection).
+ */
+public class FileStorageServiceImplTest {
+
+    private FileStorageServiceImpl storage;
+
+    @Before
+    public void setUp() {
+        storage = new FileStorageServiceImpl();
+        storage.init();
+    }
+
+    private MockMultipartFile file(String originalFilename) {
+        return new MockMultipartFile("file", originalFilename, "text/plain",
+            "CREATE TABLE t (id INT);".getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void assertRejected(String originalFilename) {
+        try {
+            storage.save(file(originalFilename));
+            fail("expected the file name to be rejected: " + originalFilename);
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void saveStoresPlainFileInsideRoot() throws Exception {
+        Resource resource = storage.save(file("simple.sql"));
+        assertTrue(resource.exists());
+        String content = StreamUtils.copyToString(resource.getInputStream(), StandardCharsets.UTF_8);
+        assertEquals("CREATE TABLE t (id INT);", content);
+    }
+
+    @Test
+    public void saveRejectsParentTraversal() {
+        assertRejected("../../../tmp/evil.sql");
+    }
+
+    @Test
+    public void saveRejectsDeepTraversal() {
+        assertRejected("../../../../../../etc/cron.d/evil");
+    }
+
+    @Test
+    public void saveRejectsBackslashTraversal() {
+        assertRejected("..\\..\\evil.sql");
+    }
+
+    @Test
+    public void saveRejectsAbsolutePath() {
+        assertRejected("/etc/passwd");
+    }
+
+    @Test
+    public void saveRejectsBlankFileName() {
+        assertRejected("   ");
+    }
+
+    @Test
+    public void saveRejectsDotSegments() {
+        assertRejected("..");
+    }
+
+    @Test
+    public void loadRejectsTraversal() {
+        try {
+            storage.load("../../etc/passwd");
+            fail("expected the load path to be rejected");
+        } catch (IllegalArgumentException e) {
+            // expected
+        }
+    }
+
+    @Test
+    public void saveThenLoadRoundTrip() throws Exception {
+        storage.save(file("round_trip.sql"));
+        Resource loaded = storage.load("round_trip.sql");
+        assertTrue(loaded.exists());
+        String content = StreamUtils.copyToString(loaded.getInputStream(), StandardCharsets.UTF_8);
+        assertEquals("CREATE TABLE t (id INT);", content);
+    }
+}

--- a/fastmodel-ide/fastmodel-ide-spi/pom.xml
+++ b/fastmodel-ide/fastmodel-ide-spi/pom.xml
@@ -44,6 +44,11 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/fastmodel-ide/fastmodel-ide-spi/pom.xml
+++ b/fastmodel-ide/fastmodel-ide-spi/pom.xml
@@ -44,11 +44,6 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/fastmodel-ide/fastmodel-ide-spi/src/main/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImpl.java
+++ b/fastmodel-ide/fastmodel-ide-spi/src/main/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImpl.java
@@ -18,9 +18,13 @@ package com.aliyun.fastmodel.ide.spi.receiver.impl;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.Inet6Address;
 import java.net.InetAddress;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.Locale;
 
@@ -55,6 +59,14 @@ public class DefaultToolServiceImpl implements ToolService {
      */
     private static final long MAX_IMPORT_BYTES = 10 * 1024 * 1024L;
 
+    /**
+     * Connect/read timeouts for the outbound import fetch. Without them a hostile or broken peer
+     * could pin a request thread forever on the unauthenticated import endpoint.
+     */
+    private static final int CONNECT_TIMEOUT_MILLIS = 5_000;
+
+    private static final int READ_TIMEOUT_MILLIS = 30_000;
+
     private final TransformerFactory transformerFactory;
 
     private final FastModelParser fastModelParser;
@@ -88,25 +100,41 @@ public class DefaultToolServiceImpl implements ToolService {
         } catch (URISyntaxException e) {
             throw new PlatformException("import by uri error" + uri, PlatformErrorCode.URL_INVALID_ERROR, e);
         }
-        validateUri(url);
-        try (InputStream in = new BoundedInputStream(url.toURL().openStream(), MAX_IMPORT_BYTES + 1)) {
+        InetAddress[] validatedAddresses = validateUri(url);
+        String text;
+        try {
+            text = fetchContent(url, validatedAddresses[0]);
+        } catch (IOException e) {
+            throw new PlatformException("import by uri error" + uri, PlatformErrorCode.READ_FILE_ERROR, e);
+        }
+        return importSql(text, dialectMeta);
+    }
+
+    /**
+     * Fetches the content with the size bound applied. Package-private so tests can exercise the
+     * bound without touching the network.
+     */
+    String fetchContent(URI uri, InetAddress validatedAddress) throws IOException {
+        try (InputStream in = new BoundedInputStream(openStream(uri, validatedAddress), MAX_IMPORT_BYTES + 1)) {
             byte[] bytes = IOUtils.toByteArray(in);
             if (bytes.length > MAX_IMPORT_BYTES) {
                 throw new PlatformException("import by uri error, content exceeds " + MAX_IMPORT_BYTES + " bytes: "
                     + uri, PlatformErrorCode.URL_INVALID_ERROR);
             }
-            return importSql(new String(bytes, UTF_8), dialectMeta);
-        } catch (IOException e) {
-            throw new PlatformException("import by uri error" + uri, PlatformErrorCode.READ_FILE_ERROR, e);
+            return new String(bytes, UTF_8);
         }
     }
 
     /**
      * Only allow fetching from http/https network addresses, and prohibit reading local files
      * (such as file://) or accessing internal network addresses (loopback, private networks,
-     * link-local addresses like cloud metadata, etc.), to prevent arbitrary file reads and SSRF.
+     * RFC 6598 shared space which hosts the cloud metadata endpoint, link-local and IPv6
+     * unique-local addresses), to prevent arbitrary file reads and SSRF.
+     *
+     * @return the resolved addresses, all validated; the caller must connect to one of these so
+     * the validated resolution is the one actually used.
      */
-    private void validateUri(URI uri) {
+    private InetAddress[] validateUri(URI uri) {
         String scheme = uri.getScheme();
         if (scheme == null || !(scheme.toLowerCase(Locale.ROOT).equals("http")
             || scheme.toLowerCase(Locale.ROOT).equals("https"))) {
@@ -118,6 +146,10 @@ public class DefaultToolServiceImpl implements ToolService {
             throw new PlatformException("import by uri error, missing host: " + uri,
                 PlatformErrorCode.URL_INVALID_ERROR);
         }
+        if (uri.getUserInfo() != null) {
+            throw new PlatformException("import by uri error, userinfo in uri is not allowed: " + uri,
+                PlatformErrorCode.URL_INVALID_ERROR);
+        }
         InetAddress[] addresses;
         try {
             addresses = InetAddress.getAllByName(host);
@@ -126,11 +158,110 @@ public class DefaultToolServiceImpl implements ToolService {
                 PlatformErrorCode.URL_INVALID_ERROR, e);
         }
         for (InetAddress address : addresses) {
-            if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
-                || address.isSiteLocalAddress() || address.isMulticastAddress()) {
+            if (isBlockedAddress(address)) {
                 throw new PlatformException("import by uri error, access to internal network address is not allowed: "
                     + host, PlatformErrorCode.URL_INVALID_ERROR);
             }
         }
+        return addresses;
+    }
+
+    /**
+     * {@link InetAddress} predicates do not cover RFC 6598 shared address space (100.64.0.0/10,
+     * which contains the ECS metadata endpoint) or IPv6 unique-local addresses (fc00::/7), and
+     * {@code isSiteLocalAddress()} only matches the deprecated fec0::/10 for IPv6, so these
+     * ranges are checked explicitly.
+     */
+    private boolean isBlockedAddress(InetAddress address) {
+        if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+            || address.isSiteLocalAddress() || address.isMulticastAddress()) {
+            return true;
+        }
+        byte[] bytes = address.getAddress();
+        if (bytes.length == 16 && isIpv4Mapped(bytes)) {
+            bytes = new byte[] {bytes[12], bytes[13], bytes[14], bytes[15]};
+        }
+        if (bytes.length == 4) {
+            int first = bytes[0] & 0xff;
+            int second = bytes[1] & 0xff;
+            // 0.0.0.0/8 ("this" network)
+            if (first == 0) {
+                return true;
+            }
+            // 100.64.0.0/10, RFC 6598 shared address space
+            return first == 100 && (second & 0xc0) == 64;
+        }
+        if (bytes.length == 16) {
+            // fc00::/7, IPv6 unique-local addresses
+            return (bytes[0] & 0xfe) == 0xfc;
+        }
+        return false;
+    }
+
+    private boolean isIpv4Mapped(byte[] bytes) {
+        for (int i = 0; i < 10; i++) {
+            if (bytes[i] != 0) {
+                return false;
+            }
+        }
+        return (bytes[10] & 0xff) == 0xff && (bytes[11] & 0xff) == 0xff;
+    }
+
+    /**
+     * Opens the import connection. Redirects are never followed: {@code validateUri} only saw the
+     * original host, so a 3xx hop could otherwise point the fetch at an internal address. For
+     * plain http the connection is pinned to the validated address literal (with the original
+     * Host header), closing the DNS re-binding window between validation and connect. For https
+     * the host name is kept so certificate validation keeps working; the re-binding window there
+     * is narrowed by the disabled redirects and the JVM DNS cache. Package-private so tests can
+     * substitute a local stream without touching the network.
+     */
+    InputStream openStream(URI uri, InetAddress validatedAddress) throws IOException {
+        if ("http".equalsIgnoreCase(uri.getScheme())) {
+            URL pinned = pinnedUrl(uri, validatedAddress);
+            HttpURLConnection conn = (HttpURLConnection)pinned.openConnection();
+            conn.setRequestProperty("Host", hostHeader(uri));
+            return checkedStream(conn, uri);
+        }
+        HttpURLConnection conn = (HttpURLConnection)uri.toURL().openConnection();
+        return checkedStream(conn, uri);
+    }
+
+    private InputStream checkedStream(HttpURLConnection conn, URI uri) throws IOException {
+        conn.setInstanceFollowRedirects(false);
+        conn.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+        conn.setReadTimeout(READ_TIMEOUT_MILLIS);
+        int status = conn.getResponseCode();
+        if (status >= 300 && status < 400) {
+            conn.disconnect();
+            throw new PlatformException("import by uri error, redirects are not allowed: " + uri,
+                PlatformErrorCode.URL_INVALID_ERROR);
+        }
+        if (status >= 400) {
+            conn.disconnect();
+            throw new IOException("import by uri error, unexpected HTTP status " + status + ": " + uri);
+        }
+        return conn.getInputStream();
+    }
+
+    private URL pinnedUrl(URI uri, InetAddress address) throws MalformedURLException {
+        String hostLiteral = address.getHostAddress();
+        if (address instanceof Inet6Address) {
+            int scope = hostLiteral.indexOf('%');
+            if (scope >= 0) {
+                hostLiteral = hostLiteral.substring(0, scope);
+            }
+            hostLiteral = "[" + hostLiteral + "]";
+        }
+        String file = uri.getRawPath() == null || uri.getRawPath().isEmpty() ? "/" : uri.getRawPath();
+        if (uri.getRawQuery() != null) {
+            file = file + "?" + uri.getRawQuery();
+        }
+        return new URL("http", hostLiteral, uri.getPort(), file);
+    }
+
+    private String hostHeader(URI uri) {
+        String host = uri.getHost();
+        return uri.getPort() > 0 ? host + ":" + uri.getPort() : host;
     }
 }

--- a/fastmodel-ide/fastmodel-ide-spi/src/main/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImpl.java
+++ b/fastmodel-ide/fastmodel-ide-spi/src/main/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImpl.java
@@ -17,8 +17,12 @@
 package com.aliyun.fastmodel.ide.spi.receiver.impl;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.UnknownHostException;
+import java.util.Locale;
 
 import com.aliyun.fastmodel.core.parser.FastModelParser;
 import com.aliyun.fastmodel.core.parser.FastModelParserFactory;
@@ -33,6 +37,7 @@ import com.aliyun.fastmodel.transform.api.context.ReverseContext.ReverseTargetSt
 import com.aliyun.fastmodel.transform.api.dialect.DialectMeta;
 import com.aliyun.fastmodel.transform.api.dialect.DialectNode;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.input.BoundedInputStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -43,6 +48,12 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * @date 2022/1/12
  */
 public class DefaultToolServiceImpl implements ToolService {
+
+    /**
+     * Maximum number of bytes allowed when importing SQL by URI, to prevent a single request from
+     * fetching unbounded content.
+     */
+    private static final long MAX_IMPORT_BYTES = 10 * 1024 * 1024L;
 
     private final TransformerFactory transformerFactory;
 
@@ -71,14 +82,55 @@ public class DefaultToolServiceImpl implements ToolService {
 
     @Override
     public String importByUri(String uri, DialectMeta dialectMeta) {
+        URI url;
         try {
-            URI url = new URI(uri);
-            String text = IOUtils.toString(url, UTF_8);
-            return importSql(text, dialectMeta);
-        } catch (IOException e) {
-            throw new PlatformException("import by uri error" + uri, PlatformErrorCode.READ_FILE_ERROR, e);
+            url = new URI(uri);
         } catch (URISyntaxException e) {
             throw new PlatformException("import by uri error" + uri, PlatformErrorCode.URL_INVALID_ERROR, e);
+        }
+        validateUri(url);
+        try (InputStream in = new BoundedInputStream(url.toURL().openStream(), MAX_IMPORT_BYTES + 1)) {
+            byte[] bytes = IOUtils.toByteArray(in);
+            if (bytes.length > MAX_IMPORT_BYTES) {
+                throw new PlatformException("import by uri error, content exceeds " + MAX_IMPORT_BYTES + " bytes: "
+                    + uri, PlatformErrorCode.URL_INVALID_ERROR);
+            }
+            return importSql(new String(bytes, UTF_8), dialectMeta);
+        } catch (IOException e) {
+            throw new PlatformException("import by uri error" + uri, PlatformErrorCode.READ_FILE_ERROR, e);
+        }
+    }
+
+    /**
+     * Only allow fetching from http/https network addresses, and prohibit reading local files
+     * (such as file://) or accessing internal network addresses (loopback, private networks,
+     * link-local addresses like cloud metadata, etc.), to prevent arbitrary file reads and SSRF.
+     */
+    private void validateUri(URI uri) {
+        String scheme = uri.getScheme();
+        if (scheme == null || !(scheme.toLowerCase(Locale.ROOT).equals("http")
+            || scheme.toLowerCase(Locale.ROOT).equals("https"))) {
+            throw new PlatformException("import by uri error, unsupported scheme: " + scheme
+                + ", only http/https are allowed", PlatformErrorCode.URL_INVALID_ERROR);
+        }
+        String host = uri.getHost();
+        if (host == null || host.isEmpty()) {
+            throw new PlatformException("import by uri error, missing host: " + uri,
+                PlatformErrorCode.URL_INVALID_ERROR);
+        }
+        InetAddress[] addresses;
+        try {
+            addresses = InetAddress.getAllByName(host);
+        } catch (UnknownHostException e) {
+            throw new PlatformException("import by uri error, unknown host: " + host,
+                PlatformErrorCode.URL_INVALID_ERROR, e);
+        }
+        for (InetAddress address : addresses) {
+            if (address.isAnyLocalAddress() || address.isLoopbackAddress() || address.isLinkLocalAddress()
+                || address.isSiteLocalAddress() || address.isMulticastAddress()) {
+                throw new PlatformException("import by uri error, access to internal network address is not allowed: "
+                    + host, PlatformErrorCode.URL_INVALID_ERROR);
+            }
         }
     }
 }

--- a/fastmodel-ide/fastmodel-ide-spi/src/test/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImplTest.java
+++ b/fastmodel-ide/fastmodel-ide-spi/src/test/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImplTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2021-2022 Alibaba Group Holding Ltd.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package com.aliyun.fastmodel.ide.spi.receiver.impl;
+
+import com.aliyun.fastmodel.ide.spi.exception.PlatformException;
+import com.aliyun.fastmodel.transform.api.dialect.DialectMeta;
+import com.aliyun.fastmodel.transform.api.dialect.DialectName;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Security tests for {@link DefaultToolServiceImpl#importByUri(String, DialectMeta)}.
+ * The URI import must only allow external http/https resources and must never read local
+ * files or internal network addresses.
+ */
+public class DefaultToolServiceImplTest {
+
+    private final DefaultToolServiceImpl toolService = new DefaultToolServiceImpl();
+
+    private final DialectMeta dialectMeta = DialectMeta.getByName(DialectName.MYSQL);
+
+    private void assertRejected(String uri, String expectedMessagePart) {
+        try {
+            toolService.importByUri(uri, dialectMeta);
+            fail("expected the uri to be rejected: " + uri);
+        } catch (PlatformException e) {
+            assertTrue("unexpected message: " + e.getMessage(),
+                e.getMessage().contains(expectedMessagePart));
+        }
+    }
+
+    @Test
+    public void importByUriRejectsFileScheme() {
+        assertRejected("file:///etc/hosts", "unsupported scheme");
+    }
+
+    @Test
+    public void importByUriRejectsJarScheme() {
+        assertRejected("jar:file:///tmp/x.jar!/a.sql", "unsupported scheme");
+    }
+
+    @Test
+    public void importByUriRejectsMissingScheme() {
+        assertRejected("/etc/hosts", "unsupported scheme");
+    }
+
+    @Test
+    public void importByUriRejectsMissingHost() {
+        assertRejected("http:///some/path.sql", "missing host");
+    }
+
+    @Test
+    public void importByUriRejectsLoopbackAddress() {
+        assertRejected("http://127.0.0.1/a.sql", "internal network address");
+    }
+
+    @Test
+    public void importByUriRejectsLinkLocalAddress() {
+        // link-local range covers the cloud metadata endpoint
+        assertRejected("http://169.254.169.254/latest/meta-data/", "internal network address");
+    }
+
+    @Test
+    public void importByUriRejectsSiteLocalAddress() {
+        assertRejected("http://10.0.0.1/a.sql", "internal network address");
+    }
+
+    @Test
+    public void importByUriRejectsInvalidSyntax() {
+        assertRejected("http://host with space/", "import by uri error");
+    }
+}

--- a/fastmodel-ide/fastmodel-ide-spi/src/test/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImplTest.java
+++ b/fastmodel-ide/fastmodel-ide-spi/src/test/java/com/aliyun/fastmodel/ide/spi/receiver/impl/DefaultToolServiceImplTest.java
@@ -16,28 +16,34 @@
 
 package com.aliyun.fastmodel.ide.spi.receiver.impl;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.net.URI;
+import java.util.Arrays;
+
 import com.aliyun.fastmodel.ide.spi.exception.PlatformException;
-import com.aliyun.fastmodel.transform.api.dialect.DialectMeta;
-import com.aliyun.fastmodel.transform.api.dialect.DialectName;
 import org.junit.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Security tests for {@link DefaultToolServiceImpl#importByUri(String, DialectMeta)}.
- * The URI import must only allow external http/https resources and must never read local
- * files or internal network addresses.
+ * Security tests for {@link DefaultToolServiceImpl#importByUri(String,
+ * com.aliyun.fastmodel.transform.api.dialect.DialectMeta)}. The URI import must only allow
+ * external http/https resources and must never read local files or internal network addresses.
  */
 public class DefaultToolServiceImplTest {
 
-    private final DefaultToolServiceImpl toolService = new DefaultToolServiceImpl();
+    private static final int MAX_IMPORT_BYTES = 10 * 1024 * 1024;
 
-    private final DialectMeta dialectMeta = DialectMeta.getByName(DialectName.MYSQL);
+    private final DefaultToolServiceImpl toolService = new DefaultToolServiceImpl();
 
     private void assertRejected(String uri, String expectedMessagePart) {
         try {
-            toolService.importByUri(uri, dialectMeta);
+            toolService.importByUri(uri, null);
             fail("expected the uri to be rejected: " + uri);
         } catch (PlatformException e) {
             assertTrue("unexpected message: " + e.getMessage(),
@@ -66,13 +72,18 @@ public class DefaultToolServiceImplTest {
     }
 
     @Test
+    public void importByUriRejectsUserInfo() {
+        assertRejected("http://user:pass@93.184.216.34/x.sql", "userinfo");
+    }
+
+    @Test
     public void importByUriRejectsLoopbackAddress() {
         assertRejected("http://127.0.0.1/a.sql", "internal network address");
     }
 
     @Test
     public void importByUriRejectsLinkLocalAddress() {
-        // link-local range covers the cloud metadata endpoint
+        // link-local range covers the AWS-style cloud metadata endpoint
         assertRejected("http://169.254.169.254/latest/meta-data/", "internal network address");
     }
 
@@ -82,7 +93,62 @@ public class DefaultToolServiceImplTest {
     }
 
     @Test
+    public void importByUriRejectsSharedAddressSpace() {
+        // 100.64.0.0/10 (RFC 6598) hosts the ECS metadata endpoint
+        assertRejected("http://100.100.100.200/latest/meta-data/", "internal network address");
+    }
+
+    @Test
+    public void importByUriRejectsThisNetworkAddress() {
+        assertRejected("http://0.1.2.3/a.sql", "internal network address");
+    }
+
+    @Test
+    public void importByUriRejectsIpv6UniqueLocalAddress() {
+        assertRejected("http://[fd00::1]/a.sql", "internal network address");
+    }
+
+    @Test
     public void importByUriRejectsInvalidSyntax() {
         assertRejected("http://host with space/", "import by uri error");
+    }
+
+    private DefaultToolServiceImpl serviceWithStubbedStream(byte[] content) {
+        return new DefaultToolServiceImpl() {
+            @Override
+            InputStream openStream(URI uri, InetAddress validatedAddress) {
+                return new ByteArrayInputStream(content);
+            }
+        };
+    }
+
+    private String stubbedFetch(byte[] content) throws Exception {
+        DefaultToolServiceImpl service = serviceWithStubbedStream(content);
+        return service.fetchContent(new URI("http://93.184.216.34/x.sql"),
+            InetAddress.getByName("93.184.216.34"));
+    }
+
+    @Test
+    public void fetchContentReturnsFetchedText() throws Exception {
+        assertEquals("CREATE TABLE t (id INT);",
+            stubbedFetch("CREATE TABLE t (id INT);".getBytes(UTF_8)));
+    }
+
+    @Test
+    public void fetchContentAcceptsExactlyMaxBytes() throws Exception {
+        byte[] content = new byte[MAX_IMPORT_BYTES];
+        Arrays.fill(content, (byte)'a');
+        assertEquals(MAX_IMPORT_BYTES, stubbedFetch(content).length());
+    }
+
+    @Test
+    public void fetchContentRejectsContentExceedingMaxBytes() throws Exception {
+        byte[] content = new byte[MAX_IMPORT_BYTES + 1];
+        try {
+            stubbedFetch(content);
+            fail("expected the oversized content to be rejected");
+        } catch (PlatformException e) {
+            assertTrue("unexpected message: " + e.getMessage(), e.getMessage().contains("exceeds"));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Fixes an unauthenticated RCE chain in `fastmodel-ide-open` (the web IDE service, default port 7001) that combines two issues:

1. **Arbitrary file read / SSRF** — `POST /engine/execute` with `IMPORT SQL ... URI '<uri>'` passed the URI directly to `IOUtils.toString(URI)`, so `file:///etc/passwd` and internal `http://` targets (e.g. cloud metadata endpoints) were fetched without restriction.
2. **Path traversal write** — `POST /engine/upload_sql` resolved the client-supplied file name directly against the temp directory, so a name like `../../../etc/cron.d/evil` wrote attacker-controlled content outside the upload directory (with `REPLACE_EXISTING`).

Combined: read a config file to locate targets, then write a cron entry (or `authorized_keys`) to gain code execution — no authentication required, as neither endpoint has any auth check.

## Changes

### SSRF hardening (`DefaultToolServiceImpl`)
- Only `http`/`https` schemes are allowed (`file://`, `jar:` etc. are rejected); URIs carrying userinfo are rejected
- Internal destinations are blocked: loopback, site-local, link-local, multicast, **RFC 6598 shared space (`100.64.0.0/10`, which hosts the ECS metadata endpoint `100.100.100.200`)**, **IPv6 unique-local (`fc00::/7`)**, `0.0.0.0/8` and IPv4-mapped forms
- **Redirects are never followed** — a 3xx hop could otherwise point the fetch at an address the validation never saw
- Plain-http connections are **pinned to the validated address literal** (with the original `Host` header), so the connection cannot be re-resolved to a different address between validation and connect (DNS-rebinding TOCTOU)
- Connect/read timeouts on the import fetch; imported content capped at 10 MB

### Upload storage hardening (`FileStorageServiceImpl`)
- File names containing path separators, the exact names `.`/`..`, or control characters are rejected (consecutive dots inside plain names like `report..final.sql` stay allowed)
- Uploads live in a dedicated directory under the temp folder; the resolved path is verified to stay inside it (defense in depth)
- A pre-planted symlink at the storage root is refused; the directory is created owner-only on POSIX
- `deleteAll()` recreates the root so save/list keep working afterwards

### Tests
- Security unit tests for both paths: scheme/address/userinfo rejections, traversal rejections, the 10 MB boundary via an injectable fetch seam, hermetic temp-dir isolation — verified to fail when the fix is reverted

### CI workflow
- Skip the `Update dependency graph` step for fork pull requests: fork PRs only receive a read-only token, so the dependency snapshot submission always failed with `Resource not accessible by integration` and marked the build red even when compilation and tests passed

### Docs
- README (EN/CN): note that the service ships without built-in authentication and should not be exposed to untrusted networks

## Verification

- `mvn test` on `fastmodel-ide-spi` and `fastmodel-ide-open` (JDK 11): all tests pass, existing behavior unchanged
- CI green on the PR branch
